### PR TITLE
Support for enums. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ choose [PojoProto], The output proto code is copied to the clipboard.
 
 * 1.0.0 - First version, support universal pojo type
 * 1.0.1 - fix some description about this plugin
+* 1.0.3 - Support for enums
 
 
 ## Plugin

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.xiaohengjin'
-version '1.0.2-SNAPSHOT'
+version '1.0.3'
 
 repositories {
     mavenLocal()

--- a/src/main/java/com/xiaohengjin/Pojo2ProtoCore.java
+++ b/src/main/java/com/xiaohengjin/Pojo2ProtoCore.java
@@ -48,7 +48,7 @@ public class Pojo2ProtoCore {
     }
 
     private void go(PsiClass clazz) {
-        if(clazz.isEnum()) {
+        if (clazz.isEnum()) {
             goEnum(clazz);
         } else {
             goClass(clazz);
@@ -86,7 +86,7 @@ public class Pojo2ProtoCore {
         int index = 0;
         // As per protobuf convention - enums should have a NONE field.
         protoContentList.add(getFieldNameForEnum(className, "NONE", index++));
-        for (PsiField field: fields) {
+        for (PsiField field : fields) {
             // Enum values are copied as-is
             protoContentList.add(getFieldNameForEnum(className, field.getName(), index++));
         }
@@ -97,9 +97,9 @@ public class Pojo2ProtoCore {
     }
 
     @VisibleForTesting
-    String getFieldNameForEnum(String enumName, String fieldName, int index){
+    String getFieldNameForEnum(String enumName, String fieldName, int index) {
         enumName = CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, enumName);
-        if(!fieldName.toUpperCase().equals(fieldName)) {
+        if (!fieldName.toUpperCase().equals(fieldName)) {
             // The field name is not in the prescribed UPPER_UNDERSCORE case, do convert.
             fieldName = CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, fieldName);
         }

--- a/src/test/java/com/xiaohengjin/Pojo2ProtoCoreTest.java
+++ b/src/test/java/com/xiaohengjin/Pojo2ProtoCoreTest.java
@@ -1,0 +1,27 @@
+package com.xiaohengjin;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class Pojo2ProtoCoreTest {
+    @Test
+    public void testEnumString(){
+        Pojo2ProtoCore pojo2ProtoCore = new Pojo2ProtoCore(Collections.emptyList());
+        assertEquals("\tTEST_ENUM_VALUE1 = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "Value1", 1));
+        assertEquals("\tTEST_ENUM_VALUE1 = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "VALUE1", 1));
+        assertEquals("\tTEST_ENUM_SOME_VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "SomeValue", 1));
+        assertEquals("\tTEST_ENUM_SOME_VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "SOME_VALUE", 1));
+
+        // This is really a bug, but cannot do much about such inconsistent naming of enum values.
+        assertEquals("\tTEST_ENUM_S_O_M_E__VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "SOME_Value", 1));
+        assertEquals("\tTEST_ENUM_SOME_VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "some_value", 1));
+
+        // Double underscore gets added if the enum name is inconsistent
+        assertEquals("\tTEST_ENUM_SOME__VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "Some_Value", 1));
+        assertEquals("\tTEST_ENUM_SOMEVALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "somevalue", 1));
+        assertEquals("\tTEST_ENUM_SOME_VALUE = 1;", pojo2ProtoCore.getFieldNameForEnum("TestEnum", "someValue", 1));
+    }
+}


### PR DESCRIPTION
This PR Fixes #1 
With the changes in this PR, generating a proto for the enum will be as below

```
enum TestEnum {
  TEST_ENUM_NONE = 0;
  TEST_ENUM_ONE = 1;
  TEST_ENUM_TWO = 2;
  TEST_ENUM_THREE = 3;
}
```